### PR TITLE
[SELS-TASK] Sprint 2 improvement

### DIFF
--- a/frontend/src/actions/types.ts
+++ b/frontend/src/actions/types.ts
@@ -10,6 +10,9 @@ import {
   TakeQuizAction,
   UnfollowUserAction,
   UpdateQuizAction,
+  UserSignInAction,
+  UserSignUpAction,
+  UserUpdateProfileAction,
 } from '.';
 import { AddQuizItemAction } from './quizItems';
 
@@ -26,6 +29,10 @@ export enum ActionTypes {
   addQuizItem,
   takeQuiz,
   fetchQuizLogs,
+  userSignIn,
+  userSignUp,
+  userSignOut,
+  userUpdateProfile,
 }
 
 export type Action =
@@ -40,4 +47,7 @@ export type Action =
   | FetchUserWithFollowsAction
   | AddQuizItemAction
   | TakeQuizAction
-  | FetchQuizLogsAction;
+  | FetchQuizLogsAction
+  | UserSignInAction
+  | UserSignUpAction
+  | UserUpdateProfileAction;

--- a/frontend/src/actions/users.ts
+++ b/frontend/src/actions/users.ts
@@ -1,8 +1,9 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { useCookies } from 'react-cookie';
 import { Dispatch } from 'redux';
 import { ActionTypes } from '.';
 import backend from '../api/backend';
 import { User } from '../components/AdminUser';
-import { StoreState } from '../reducers';
 
 export interface UsersData {
   data?: User[];
@@ -12,6 +13,7 @@ export interface UsersData {
 
 export interface UserData {
   data?: User;
+  token?: string;
 }
 
 export interface FetchUsersAction {
@@ -31,6 +33,21 @@ export interface UnfollowUserAction {
 
 export interface FetchUserWithFollowsAction {
   type: ActionTypes.fetchUserWithFollows;
+  payload: UserData;
+}
+
+export interface UserSignInAction {
+  type: ActionTypes.userSignIn;
+  payload: UserData;
+}
+
+export interface UserSignUpAction {
+  type: ActionTypes.userSignUp;
+  payload: UserData;
+}
+
+export interface UserUpdateProfileAction {
+  type: ActionTypes.userUpdateProfile;
   payload: UserData;
 }
 
@@ -129,6 +146,174 @@ export const unfollowUser = (data: {
         type: ActionTypes.unfollowUser,
         payload: user_id,
       });
+    });
+  };
+};
+
+export const userSignIn = (data: {
+  email: number;
+  password: string;
+  callback: Function;
+  errorCallback: Function;
+}) => {
+  return async (dispatch: Dispatch) => {
+    backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let { email, password, callback, errorCallback } = data;
+
+      await backend
+        .post<UserData>('/api/login', {
+          email,
+          password,
+        })
+        .then((response) => {
+          callback(response);
+
+          dispatch<UserSignInAction>({
+            type: ActionTypes.userSignIn,
+            payload: response.data,
+          });
+        })
+        .catch(() => {
+          errorCallback();
+        });
+    });
+  };
+};
+
+export const userSignUp = (data: {
+  name: string;
+  email: string;
+  password: string;
+  password_confirmation: string;
+  callback: Function;
+  errorCallback: Function;
+}) => {
+  return async (dispatch: Dispatch) => {
+    backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let {
+        name,
+        email,
+        password,
+        password_confirmation,
+        callback,
+        errorCallback,
+      } = data;
+
+      await backend
+        .post<UserData>('/api/users', {
+          name,
+          email,
+          password,
+          password_confirmation,
+        })
+        .then((response) => {
+          callback(response);
+
+          dispatch<UserSignUpAction>({
+            type: ActionTypes.userSignUp,
+            payload: response.data,
+          });
+        })
+        .catch(() => {
+          errorCallback();
+        });
+    });
+  };
+};
+
+export const userSignOut = (data: {
+  token: string;
+  callback: Function;
+  errorCallback: Function;
+}) => {
+  return async (dispatch: Dispatch) => {
+    backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let { token, callback, errorCallback } = data;
+
+      await backend
+        .post(
+          '/api/logout',
+          {},
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        )
+        .then((response) => {
+          callback(response);
+        })
+        .catch(() => {
+          errorCallback();
+        });
+    });
+  };
+};
+
+export const userUpdateProfileDetails = (data: {
+  user_id: number;
+  name: string;
+  email: string;
+  callback: Function;
+  errorCallback: Function;
+  finallyCallback: Function;
+}) => {
+  return async (dispatch: Dispatch) => {
+    backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let { user_id, name, email, callback, errorCallback, finallyCallback } =
+        data;
+
+      await backend
+        .put<UserData>(`/api/users/${user_id}`, {
+          name,
+          email,
+        })
+        .then((response: AxiosResponse) => {
+          callback(response);
+
+          dispatch<UserUpdateProfileAction>({
+            type: ActionTypes.userUpdateProfile,
+            payload: response.data,
+          });
+        })
+        .catch((err: AxiosError) => {
+          errorCallback(err);
+        })
+        .finally(() => finallyCallback());
+    });
+  };
+};
+
+export const userUpdateProfileAvatar = (data: {
+  user_id: number;
+  formdata: FormData;
+  callback: Function;
+  errorCallback: Function;
+  finallyCallback: Function;
+}) => {
+  return async (dispatch: Dispatch) => {
+    backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let { user_id, formdata, callback, errorCallback, finallyCallback } =
+        data;
+
+      await backend
+        .post<UserData>(`/api/users/${user_id}`, formdata, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        })
+        .then((response: AxiosResponse) => {
+          callback(response);
+
+          dispatch<UserUpdateProfileAction>({
+            type: ActionTypes.userUpdateProfile,
+            payload: response.data,
+          });
+        })
+        .catch((err: AxiosError) => {
+          errorCallback(err);
+        })
+        .finally(() => finallyCallback());
     });
   };
 };

--- a/frontend/src/components/Header/HeaderAuth.tsx
+++ b/frontend/src/components/Header/HeaderAuth.tsx
@@ -41,13 +41,15 @@ const HeaderAuth = () => {
       </Link>
     </div>
   ) : (
-    <HeaderDropDown label={cookies.user?.name} dropDownItems={userOptions}>
-      <div>
-        <h3 className="text-sm tracking-wide font-medium text-gray-500 uppercase">
-          Welcome Back!
-        </h3>
-      </div>
-    </HeaderDropDown>
+    <div className="hidden md:flex items-center justify-end md:flex-1 lg:w-0">
+      <HeaderDropDown label={cookies.user?.name} dropDownItems={userOptions}>
+        <div>
+          <h3 className="text-sm tracking-wide font-medium text-gray-500 uppercase">
+            Welcome Back!
+          </h3>
+        </div>
+      </HeaderDropDown>
+    </div>
   );
 };
 

--- a/frontend/src/components/Header/HeaderDropDown.tsx
+++ b/frontend/src/components/Header/HeaderDropDown.tsx
@@ -56,7 +56,7 @@ const HeaderDropDown = ({
               <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
                 <div className="relative grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8">
                   {dropDownItems.map((item) => (
-                    <HeaderDropDownItem item={item} />
+                    <HeaderDropDownItem key={item.name} item={item} />
                   ))}
                 </div>
                 <div className="px-5 py-5 bg-gray-50 space-y-6 sm:flex sm:space-y-0 sm:space-x-10 sm:px-8">

--- a/frontend/src/components/Header/HeaderDropDownItem.tsx
+++ b/frontend/src/components/Header/HeaderDropDownItem.tsx
@@ -8,7 +8,6 @@ interface HeaderDropDownItemProps {
 const HeaderDropDownItem = ({ item }: HeaderDropDownItemProps) => {
   return (
     <Link
-      key={item.name}
       to={item.href}
       className="-m-3 p-3 flex items-start rounded-lg hover:bg-gray-50"
     >

--- a/frontend/src/components/Header/HeaderItem.tsx
+++ b/frontend/src/components/Header/HeaderItem.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 interface HeaderItemProps {
   label: string;
   href?: string;
@@ -5,12 +7,12 @@ interface HeaderItemProps {
 
 const HeaderItem = ({ label, href = '#' }: HeaderItemProps) => {
   return (
-    <a
-      href={href}
+    <Link
+      to={href}
       className="text-base font-medium text-gray-500 hover:text-gray-900"
     >
       {label}
-    </a>
+    </Link>
   );
 };
 

--- a/frontend/src/components/Header/HeaderLinks.tsx
+++ b/frontend/src/components/Header/HeaderLinks.tsx
@@ -3,8 +3,11 @@ import { Popover } from '@headlessui/react';
 import HeaderItem from './HeaderItem';
 import HeaderDropDown from './HeaderDropDown';
 import { callsToAction, solutions, recentPosts } from '.';
+import { useCookies } from 'react-cookie';
 
 const HeaderLinks = () => {
+  const [cookies, setCookies] = useCookies();
+
   return (
     <Popover.Group as="nav" className="hidden md:flex space-x-10">
       {/* <HeaderDropDown
@@ -13,8 +16,12 @@ const HeaderLinks = () => {
         callToActions={callsToAction}
       /> */}
 
-      <HeaderItem label="Quizzes" href="/quizzes" />
-      <HeaderItem label="Users" href="/users" />
+      {cookies.user && (
+        <>
+          <HeaderItem label="Quizzes" href="/quizzes" />
+          <HeaderItem label="Users" href="/users" />
+        </>
+      )}
 
       {/* <HeaderDropDown label="Quizzes" dropDownItems={solutions}>
         <div>

--- a/frontend/src/components/Header/HeaderLogo.tsx
+++ b/frontend/src/components/Header/HeaderLogo.tsx
@@ -1,14 +1,16 @@
+import { Link } from 'react-router-dom';
+
 const HeaderLogo = () => {
   return (
-    <div className="flex justify-start lg:w-0 lg:flex-1">
-      <a href="#">
+    <div className="flex lg:w-0 lg:flex-1">
+      <Link to="/">
         <span className="sr-only">Workflow</span>
         <img
           className="h-8 w-auto sm:h-10"
           src="https://tailwindui.com/img/logos/workflow-mark-indigo-600.svg"
           alt=""
         />
-      </a>
+      </Link>
     </div>
   );
 };

--- a/frontend/src/components/UserAuth/UserSignOut.tsx
+++ b/frontend/src/components/UserAuth/UserSignOut.tsx
@@ -1,34 +1,33 @@
 import { Backdrop, CircularProgress } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
+import { connect } from 'react-redux';
 import { useNavigate } from 'react-router';
-import backend from '../../api/backend';
+import { userSignOut } from '../../actions';
+import { StoreState } from '../../reducers';
 
-interface Props {}
+interface Props {
+  userSignOut: Function;
+}
 
-export const UserSignOut = (props: Props) => {
+export const _UserSignOut = ({ userSignOut }: Props) => {
   const [cookies, setCookies, removeCookies] = useCookies();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
     setOpen(true);
-    backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
-      const response = await backend.post<any>(
-        '/api/logout/',
-        {},
-        {
-          headers: {
-            Authorization: `Bearer ${cookies.token}`,
-          },
-        }
-      );
+    let signOutData = {
+      token: cookies.token,
+      callback: () => {
+        removeCookies('user', { path: '/' });
+        removeCookies('token', { path: '/' });
+        setOpen(false);
+        navigate('/');
+      },
+    };
 
-      removeCookies('user', { path: '/' });
-      removeCookies('token', { path: '/' });
-      setOpen(false);
-      navigate('/');
-    });
+    userSignOut(signOutData);
   }, []);
 
   return (
@@ -40,5 +39,14 @@ export const UserSignOut = (props: Props) => {
     </Backdrop>
   );
 };
+
+const mapStateToProps = ({}: StoreState): {} => {
+  return {};
+};
+
+export const UserSignOut = connect(mapStateToProps, { userSignOut })(
+  _UserSignOut
+);
+
 
 export default UserSignOut;

--- a/frontend/src/components/UserList/UserList.tsx
+++ b/frontend/src/components/UserList/UserList.tsx
@@ -32,8 +32,8 @@ export const UserList = ({
   const [cookies, setCookies] = useCookies();
 
   useEffect(() => {
-    fetchUsers();
     fetchUserWithFollows(cookies.token);
+    fetchUsers();
     return () => {};
   }, []);
 

--- a/frontend/src/components/UserProfile/UserProfileEditDetails.tsx
+++ b/frontend/src/components/UserProfile/UserProfileEditDetails.tsx
@@ -1,10 +1,8 @@
-import styled from '@emotion/styled';
 import { AxiosResponse, AxiosError } from 'axios';
 import React, { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
-import backend from '../../api/backend';
 
 import {
   Box,
@@ -14,6 +12,9 @@ import {
   CircularProgress,
   Button,
 } from '@mui/material';
+import { connect } from 'react-redux';
+import { userUpdateProfileDetails } from '../../actions';
+import { StoreState } from '../../reducers';
 
 export interface ProfileEditInput {
   name: string;
@@ -43,9 +44,13 @@ const formValidation = {
   },
 };
 
-interface Props {}
+interface Props {
+  userUpdateProfileDetails: Function;
+}
 
-export const UserProfileEditDetails = (props: Props) => {
+export const _UserProfileEditDetails = ({
+  userUpdateProfileDetails,
+}: Props) => {
   const {
     register,
     handleSubmit,
@@ -76,24 +81,27 @@ export const UserProfileEditDetails = (props: Props) => {
     setLoading(true);
     setError(false);
     setSuccess(false);
-    backend.get('/sanctum/csrf-cookie').then((csrf_response) => {
-      backend
-        .put(`/api/users/${cookies.user.id}`, data)
-        .then((response: AxiosResponse) => {
-          setSuccess(true);
-          setMsg('Profile Updated Successfully');
-          let data = response.data?.data;
-          setCookies('user', data, { path: '/' });
-        })
-        .catch((err: AxiosError) => {
-          setError(true);
-          let errordata = err.response?.data;
-          setMsg(errordata?.error?.message);
-        })
-        .finally(() => {
-          setLoading(false);
-        });
-    });
+    let profileData = {
+      user_id: cookies.user.id,
+      name: data.name,
+      email: data.email,
+      callback: (response: AxiosResponse) => {
+        setSuccess(true);
+        setMsg('Profile Updated Successfully');
+        let data = response.data?.data;
+        setCookies('user', data, { path: '/' });
+      },
+      errorCallback: (err: AxiosError) => {
+        setError(true);
+        let errordata = err.response?.data;
+        setMsg(errordata?.error?.message);
+      },
+      finallyCallback: () => {
+        setLoading(false);
+      },
+    };
+
+    userUpdateProfileDetails(profileData);
   };
 
   return (
@@ -144,5 +152,13 @@ export const UserProfileEditDetails = (props: Props) => {
     </Box>
   );
 };
+
+const mapStateToProps = ({}: StoreState): {} => {
+  return {};
+};
+
+export const UserProfileEditDetails = connect(mapStateToProps, {
+  userUpdateProfileDetails,
+})(_UserProfileEditDetails);
 
 export default UserProfileEditDetails;

--- a/frontend/src/components/UserQuizzes/UserQuizzes.tsx
+++ b/frontend/src/components/UserQuizzes/UserQuizzes.tsx
@@ -31,6 +31,7 @@ export const _UserQuizzes = ({
   const [search, setSearch] = useState('');
 
   useEffect(() => {
+    fetchQuizLogs(cookies.token);
     fetchQuizzes();
     fetchQuizLogs(cookies.token);
     return () => {};

--- a/frontend/src/components/UserQuizzes/UserQuizzes.tsx
+++ b/frontend/src/components/UserQuizzes/UserQuizzes.tsx
@@ -33,7 +33,6 @@ export const _UserQuizzes = ({
   useEffect(() => {
     fetchQuizLogs(cookies.token);
     fetchQuizzes();
-    fetchQuizLogs(cookies.token);
     return () => {};
   }, []);
 


### PR DESCRIPTION
Subbranch of PR #41 

Asana [Task](https://app.asana.com/0/1201478050789792/1201643804188430/f)

expected output:

- sign in / sign up loading state

- user list
  - fetch current logged in user's following list first, then the list of users
  - currently there will be a time where the follow button is set to `follow` despite the user already following that user implementing this will make it sure that the following list will load first

- user quizzes
  - same issue with user list
  - the taken quiz loads later so the quiz list will have the start button available on the taken quizzes for just a moment hide 

- header links when not logged in
- separate actions from frontend
  - signin / signup
  - update profile
- use of <Link> instead of <a>
- center user links (bug)