### PR TITLE
[SELS-BUGFIX] use callback for fetching following and quiz_logs

### DIFF
--- a/frontend/src/actions/quizzes.ts
+++ b/frontend/src/actions/quizzes.ts
@@ -48,12 +48,16 @@ export interface TakeQuizAction {
   payload: number;
 }
 
-export const fetchQuizzes = (search: string = '') => {
+export const fetchQuizzes = (data: { search: string; callback: Function }) => {
   return async (dispatch: Dispatch) => {
     backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let { search, callback } = data;
+
       const response = await backend.get<QuizzesData>(
         search !== '' ? `/api/quizzes?search=${search ?? ''}` : `/api/quizzes/`
       );
+
+      if (callback) callback();
 
       dispatch<FetchQuizzesAction>({
         type: ActionTypes.fetchQuizzes,
@@ -105,9 +109,11 @@ export const updateQuiz = (quizId: string | undefined, quiz: Quiz) => {
   };
 };
 
-export const fetchQuizLogs = (token: string, callback: Function = () => {}) => {
+export const fetchQuizLogs = (data: { token: string; callback: Function }) => {
   return async (dispatch: Dispatch) => {
     backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let { token, callback } = data;
+
       const response = await backend.get<UserData>(`/api/quiz_logs/`, {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/frontend/src/actions/users.ts
+++ b/frontend/src/actions/users.ts
@@ -50,10 +50,14 @@ export interface UserUpdateProfileAction {
   payload: UserData;
 }
 
-export const fetchUsers = () => {
+export const fetchUsers = (data: { callback: Function }) => {
   return async (dispatch: Dispatch) => {
     backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let { callback } = data;
+
       const response = await backend.get<UsersData>('/api/users/');
+
+      if (callback) callback();
 
       dispatch<FetchUsersAction>({
         type: ActionTypes.fetchUsers,
@@ -63,20 +67,22 @@ export const fetchUsers = () => {
   };
 };
 
-export const fetchUserWithFollows = (
-  token: string,
-  id?: number,
-  callback: Function = () => {}
-) => {
+export const fetchUserWithFollows = (data: {
+  token: string;
+  id?: number;
+  callback: Function;
+}) => {
   return async (dispatch: Dispatch) => {
     backend.get('/sanctum/csrf-cookie').then(async (csrf_response) => {
+      let { token, id, callback } = data;
+
       const response = await backend.get<UserData>(`/api/follows/${id ?? ''}`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       });
 
-      callback();
+      if (callback) callback();
 
       dispatch<FetchUserWithFollowsAction>({
         type: ActionTypes.fetchUserWithFollows,

--- a/frontend/src/components/UserList/UserList.tsx
+++ b/frontend/src/components/UserList/UserList.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { UserListData } from '.';
 
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import { User } from '../AdminUser';
 import { GridRenderCellParams } from '@mui/x-data-grid';
 import { useCookies } from 'react-cookie';
+import { CircularProgress, Stack } from '@mui/material';
 
 interface Props {
   fetchUsers: Function;
@@ -30,11 +31,20 @@ export const UserList = ({
   usersWithFollows,
 }: Props): JSX.Element => {
   const [cookies] = useCookies();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    fetchUserWithFollows(cookies.token);
-    fetchUsers();
-    return () => {};
+    setLoading(true);
+    fetchUserWithFollows({
+      token: cookies.token,
+      callback: () => {
+        fetchUsers({
+          callback: () => {
+            setLoading(false);
+          },
+        });
+      },
+    });
   }, [fetchUsers, fetchUserWithFollows, cookies]);
 
   const handleFollowClick = (
@@ -49,11 +59,16 @@ export const UserList = ({
       callback: callback,
     };
     params.row.is_following ? unfollowUser(data) : followUser(data);
-    fetchUserWithFollows(cookies.token);
+    fetchUserWithFollows({ token: cookies.token });
   };
 
   return (
     <div className="container mx-auto mt-20 h-screen">
+      {loading && (
+        <Stack alignItems="center" className="mb-5">
+          <CircularProgress />
+        </Stack>
+      )}
       <div className="flex mx-auto h-4/6 w-1/2 ">
         <div className="flex-grow">
           <UserListData

--- a/frontend/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/UserProfile/UserProfile.tsx
@@ -8,7 +8,7 @@ import { useParams } from 'react-router';
 import { connect } from 'react-redux';
 import { fetchUserWithFollows, followUser, unfollowUser } from '../../actions';
 import { StoreState } from '../../reducers';
-import { Avatar, CircularProgress } from '@mui/material';
+import { Avatar, CircularProgress, Skeleton, Stack } from '@mui/material';
 import { useCookies } from 'react-cookie';
 
 const sampleActs = [
@@ -49,25 +49,35 @@ const _UserProfile = ({
   let { id } = useParams();
 
   const [cookies] = useCookies();
-  const [loading, setLoading] = useState(false);
+  const [loadingFollow, setLoadingFollow] = useState(false);
+  const [loadingUserData, setLoadingUserData] = useState(false);
   const [isFollowing, setIsFollowing] = useState(false);
 
   const handleFollowClick = (e: any) => {
-    setLoading(true);
+    setLoadingFollow(true);
     let data = {
       user_id: user?.id,
       token: cookies.token,
       callback: () => {
-        setLoading(false);
+        setLoadingFollow(false);
         setIsFollowing(false);
-        fetchUserWithFollows(cookies.token, id);
+        fetchUserWithFollows({ token: cookies.token, id: id });
       },
     };
     isFollowing ? unfollowUser(data) : followUser(data);
   };
 
   useEffect(() => {
-    fetchUserWithFollows(cookies.token, id);
+    setLoadingUserData(true);
+    setLoadingFollow(true);
+    fetchUserWithFollows({
+      token: cookies.token,
+      id: id,
+      callback: () => {
+        setLoadingUserData(false);
+        setLoadingFollow(false);
+      },
+    });
   }, [cookies, fetchUserWithFollows, id]);
 
   useEffect(() => {
@@ -88,20 +98,30 @@ const _UserProfile = ({
     <div className="container mx-auto px-24 py-8">
       <div className="grid grid-cols-6">
         <div className="col-span-2 mr-4 px-10">
-          {user?.avatar ? (
-            <img
-              className="mx-auto mt-4"
-              src={user?.avatar}
-              width={200}
-              height={200}
-              alt="user avatar"
-            />
+          {loadingUserData ? (
+            <Stack alignItems="center" className="mb-5">
+              <Skeleton variant="rectangular" width={200} height={200} />
+              <Skeleton variant="text" width={150} height={50} />
+            </Stack>
           ) : (
-            <Avatar alt={user?.name}>{user?.name[0]}</Avatar>
+            <>
+              {' '}
+              {user?.avatar ? (
+                <img
+                  className="mx-auto mt-4"
+                  src={user?.avatar}
+                  width={200}
+                  height={200}
+                  alt="user avatar"
+                />
+              ) : (
+                <Avatar alt={user?.name}>{user?.name[0]}</Avatar>
+              )}
+              <div className="my-4 mx-auto text-center font-semibold text-xl">
+                {user?.name}
+              </div>
+            </>
           )}
-          <div className="my-4 mx-auto text-center font-semibold text-xl">
-            {user?.name}
-          </div>
           <Divider />
 
           <div className="grid grid-cols-2 text-center my-4">
@@ -110,7 +130,7 @@ const _UserProfile = ({
           </div>
 
           <div className="my-4 text-center">
-            {loading ? (
+            {loadingFollow ? (
               <CircularProgress />
             ) : (
               <Chip


### PR DESCRIPTION
Asana [Task](https://app.asana.com/0/1201478050789792/1201650289352197/f)

expected output:
previously, the user list data will load first, then the next api call for getting the following list of the current user will load

this means that for a moment, the follow button will not be updated until the fetch for the user list is done

same is true with the quizzes, where the start button will be available for a moment until the next api for getting the list of taken quizzes is done

also included some loading states

also added skeleton loading for the user profile page

screenshots:
![image](https://user-images.githubusercontent.com/95029803/149264475-57e394e5-4049-4d0c-86e4-158c360b1889.png)

![image](https://user-images.githubusercontent.com/95029803/149264489-c133ab24-a031-4cdc-9941-10e914b588f2.png)

![image](https://user-images.githubusercontent.com/95029803/149264503-b8482acc-59db-4efc-8b84-385c52a7a7b5.png)

![image](https://user-images.githubusercontent.com/95029803/149265498-c1b8e89d-f4ae-4fe9-9d08-8e42f72a0cab.png)
