### PR TITLE
[SELS-TASK] Configure activity logs api

### DIFF
--- a/backend/app/Http/Controllers/ActivityLogController.php
+++ b/backend/app/Http/Controllers/ActivityLogController.php
@@ -2,8 +2,25 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 
 class ActivityLogController extends Controller {
-    //
+    public function index() {
+        return $this->getUserWithActivityLogs(Auth::id());
+    }
+
+    public function show($id) {
+        return $this->getUserWithActivityLogs($id);
+    }
+
+    protected function getUserWithActivityLogs($id) {
+        return response()->json([
+            "data" => User::where('id', $id)->with([
+                'quiz_logs.log',
+                'following.log',
+                'followers.log'
+            ])->first()
+        ]);
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\FollowController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -33,4 +34,5 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::apiResource('follows', FollowController::class)->only('index', 'store', 'show');
     Route::delete('follows', [FollowController::class, 'destroy']);
     Route::apiResource('quiz_logs', QuizLogController::class)->only('index', 'store', 'show');
+    Route::apiResource('activity_logs', ActivityLogController::class)->only('index', 'show');
 });


### PR DESCRIPTION
Subbranch of PR 42

Asana [Task](https://app.asana.com/0/1201478050789792/1201650289352193/f)

expected output:
/api/activity_logs   is setup and will return the user data with the quiz logs and the follow logs

available routes:
/api/activity_logs    show the activity logs of the logged in user
/api/activity_logs/:id   show the activity logs of the user with id

screenshots:
![image](https://user-images.githubusercontent.com/95029803/149274286-107cd420-6691-44df-9c8a-4a473c7f128b.png)

![image](https://user-images.githubusercontent.com/95029803/149274306-aaf3987c-374d-4202-b25b-88128bea399b.png)
