### PR TITLE
[SELS-TASK] User can see the number of quizzes and words learned

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -18,7 +18,6 @@ import UserList from './UserList';
 import UserDashboard from './UserDashboard';
 import UserQuizAnswer from './UserQuizAnswer';
 import UserQuizResult from './UserQuizResult';
-import UserLearnedWords from './UserDashboard/UserLearnedWords';
 
 function Home() {
   return <h1 className="text-3xl font-bold underline">Home!</h1>;
@@ -75,10 +74,6 @@ function App() {
             <Route
               path="/dashboard"
               element={<AuthRoute element={<UserDashboard />} />}
-            />
-            <Route
-              path="/learned_words"
-              element={<AuthRoute element={<UserLearnedWords />} />}
             />
             <Route
               path="/users"

--- a/frontend/src/components/UserDashboard/UserDashboard.tsx
+++ b/frontend/src/components/UserDashboard/UserDashboard.tsx
@@ -31,6 +31,8 @@ interface Props {
   user: User | null;
   activities: Activity[] | null;
   learnedWordsRows: LearnedWordsRow[] | null;
+  learnedWordsNum: number;
+  learnedQuizzesNum: number;
   fetchUserWithLogs: Function;
   userDataCleanup: Function;
   fetchLearnedWords: Function;
@@ -41,6 +43,8 @@ export const _UserDashboard = ({
   activities,
   fetchUserWithLogs,
   learnedWordsRows,
+  learnedWordsNum,
+  learnedQuizzesNum,
   userDataCleanup,
   fetchLearnedWords,
 }: Props) => {
@@ -104,8 +108,8 @@ export const _UserDashboard = ({
             </Stack>
           ) : (
             <div className="grid grid-cols-2 text-center my-4">
-              <div>Learned 20 words</div>
-              <div>Learned 5 lessons</div>
+              <div>Learned {learnedWordsNum} words</div>
+              <div>Learned {learnedQuizzesNum} quizzes</div>
             </div>
           )}
 
@@ -143,9 +147,13 @@ const mapStateToProps = ({
   user: User | null;
   activities: Activity[] | null;
   learnedWordsRows: LearnedWordsRow[] | null;
+  learnedWordsNum: number;
+  learnedQuizzesNum: number;
 } => {
   let user = userData.data || null;
   let learnedWords = learnedWordsData.data || null;
+  let learnedWordsNum = 0;
+  let learnedQuizzesNum = user?.quiz_logs?.length || 0;
 
   let activities = getActivities(user);
   sortActivities(activities);
@@ -157,6 +165,7 @@ const mapStateToProps = ({
 
   if (learnedWords) {
     for (let row of learnedWords) {
+      learnedWordsNum++;
       if (isQuestion1) {
         tempRow.id = currentIndex;
         tempRow.question1 = row['question'];
@@ -177,7 +186,13 @@ const mapStateToProps = ({
     }
   }
 
-  return { user, activities, learnedWordsRows };
+  return {
+    user,
+    activities,
+    learnedWordsRows,
+    learnedWordsNum,
+    learnedQuizzesNum,
+  };
 };
 
 export const UserDashboard = connect(mapStateToProps, {

--- a/frontend/src/components/UserDashboard/UserDashboard.tsx
+++ b/frontend/src/components/UserDashboard/UserDashboard.tsx
@@ -114,9 +114,13 @@ export const _UserDashboard = ({
             </Stack>
           ) : (
             <div className="grid grid-cols-2 text-center my-4">
-              <div>Learned {simple_to_plural(learnedWordsNum, 'word')}</div>
               <div>
-                Learned {simple_to_plural(learnedQuizzesNum, 'quiz', 'zes')}
+                Learned {learnedWordsNum}{' '}
+                {simple_to_plural(learnedWordsNum, 'word')}
+              </div>
+              <div>
+                Learned {learnedQuizzesNum}{' '}
+                {simple_to_plural(learnedQuizzesNum, 'quiz', 'zes')}
               </div>
             </div>
           )}

--- a/frontend/src/components/UserDashboard/UserDashboard.tsx
+++ b/frontend/src/components/UserDashboard/UserDashboard.tsx
@@ -114,13 +114,9 @@ export const _UserDashboard = ({
             </Stack>
           ) : (
             <div className="grid grid-cols-2 text-center my-4">
+              <div>Learned {simple_to_plural(learnedWordsNum, 'word')}</div>
               <div>
-                Learned {learnedWordsNum}{' '}
-                {simple_to_plural(learnedWordsNum, 'word')}
-              </div>
-              <div>
-                Learned {learnedQuizzesNum}{' '}
-                {simple_to_plural(learnedQuizzesNum, 'quiz', 'zes')}
+                Learned {simple_to_plural(learnedQuizzesNum, 'quiz', 'zes')}
               </div>
             </div>
           )}

--- a/frontend/src/components/UserDashboard/UserDashboard.tsx
+++ b/frontend/src/components/UserDashboard/UserDashboard.tsx
@@ -4,7 +4,13 @@ import {
   userDataCleanup,
   fetchLearnedWords,
 } from '../../actions';
-import { TabPanel, a11yProps, UserLearnedWords, LearnedWordsRow } from '.';
+import {
+  TabPanel,
+  a11yProps,
+  UserLearnedWords,
+  LearnedWordsRow,
+  simple_to_plural,
+} from '.';
 
 import { connect } from 'react-redux';
 import { useCookies } from 'react-cookie';
@@ -108,8 +114,10 @@ export const _UserDashboard = ({
             </Stack>
           ) : (
             <div className="grid grid-cols-2 text-center my-4">
-              <div>Learned {learnedWordsNum} words</div>
-              <div>Learned {learnedQuizzesNum} quizzes</div>
+              <div>Learned {simple_to_plural(learnedWordsNum, 'word')}</div>
+              <div>
+                Learned {simple_to_plural(learnedQuizzesNum, 'quiz', 'zes')}
+              </div>
             </div>
           )}
 

--- a/frontend/src/components/UserDashboard/index.tsx
+++ b/frontend/src/components/UserDashboard/index.tsx
@@ -5,7 +5,7 @@ export const simple_to_plural = (
   word: string,
   suffix: string = 's'
 ) => {
-  return count > 1 ? `${word}${suffix}` : word;
+  return count > 1 ? `${count} ${word}${suffix}` : `${count} ${word}`;
 };
 
 export * from './UserDashboard';

--- a/frontend/src/components/UserDashboard/index.tsx
+++ b/frontend/src/components/UserDashboard/index.tsx
@@ -1,5 +1,13 @@
 import UserDashboard from './UserDashboard';
 
+export const simple_to_plural = (
+  count: number,
+  word: string,
+  suffix: string = 's'
+) => {
+  return count > 1 ? `${word}${suffix}` : word;
+};
+
 export * from './UserDashboard';
 export * from './UserLearnedWords';
 export * from './TabPanel';


### PR DESCRIPTION
Subbranch of PR #60

Asana [Task](https://app.asana.com/0/1201478050789792/1201491857751491/f)

expected output:
when viewing the user dashboard, the number of quizzes learned, 
and the number of words learned will be available to the user

also created a helper function to handle singular/plural forms of `words` and `quizzes`
-> returns `count word(suffix)`
-> `1 word` or `3 quizzes`


screenshots:
![image](https://user-images.githubusercontent.com/95029803/149862835-da16ae15-15e3-4e2f-b652-8b506e3a8bdf.png)
