### PR TITLE
[SELS-BUGFIX] Activity logs should be in latest order

### DIFF
--- a/frontend/src/components/UserProfile/Activities.tsx
+++ b/frontend/src/components/UserProfile/Activities.tsx
@@ -6,7 +6,7 @@ import ListItemAvatar from '@mui/material/ListItemAvatar';
 import Avatar from '@mui/material/Avatar';
 
 import { Skeleton, Stack } from '@mui/material';
-import { Activity } from '.';
+import { Activity, sortLogs } from '.';
 import { Link } from 'react-router-dom';
 
 import TimeAgo from 'react-timeago';
@@ -25,6 +25,7 @@ export const Activities = ({ activities = [] }: Props) => {
   const renderListItem = (act: Activity) => {
     const date = new Date(act.created_at);
     let act_logs = Array.isArray(act?.log) ? act?.log : [act?.log];
+    sortLogs(act_logs);
 
     return act_logs.map((act_log) => {
       const [doer, action, recipient] = JSON.parse(act_log.message);

--- a/frontend/src/components/UserProfile/activitiesHelper.tsx
+++ b/frontend/src/components/UserProfile/activitiesHelper.tsx
@@ -44,6 +44,15 @@ export const sortActivities = (acitvities: Activity[] | null) => {
     let aDate = new Date(a.created_at);
     let bDate = new Date(b.created_at);
 
-    return aDate.getTime() - bDate.getTime();
+    return bDate.getTime() - aDate.getTime();
+  });
+};
+
+export const sortLogs = (logs: ActivityLog[] | null) => {
+  logs?.sort((a, b) => {
+    let aDate = new Date(a.created_at);
+    let bDate = new Date(b.created_at);
+
+    return bDate.getTime() - aDate.getTime();
   });
 };


### PR DESCRIPTION
Asana [Task](https://app.asana.com/0/1201478050789792/1201668705387967/f)

expected output:
activities and logs should now be in latest order

screenshots:
before
![image](https://user-images.githubusercontent.com/95029803/149868062-5461adab-36b6-4519-9be6-160c104ac661.png)


after
![image](https://user-images.githubusercontent.com/95029803/149868094-2051690d-26c9-4fce-80d3-a572a85e6ac2.png)
