### PR TITLE
[SELS-TASK] Delete quiz log when not answered

### DIFF
--- a/backend/app/Events/QuizLogRetrieved.php
+++ b/backend/app/Events/QuizLogRetrieved.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\QuizLog;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class QuizLogRetrieved {
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public QuizLog $quiz_log) {
+    }
+
+    public function broadcastOn() {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/backend/app/Listeners/HandleQuizLogRetrieved.php
+++ b/backend/app/Listeners/HandleQuizLogRetrieved.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\QuizLogRetrieved;
+use Carbon\Carbon;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class HandleQuizLogRetrieved {
+    public function __construct() {
+    }
+
+    public function handle(QuizLogRetrieved $event) {
+        $quiz_log = $event->quiz_log;
+        if (
+            $quiz_log->answers()->get()->count() === 0 &&
+            now()->diffInMinutes($quiz_log->created_at) >= 1
+        ) {
+            $quiz_log->delete();
+        }
+    }
+}

--- a/backend/app/Models/QuizLog.php
+++ b/backend/app/Models/QuizLog.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Events\QuizLogCreated;
+use App\Events\QuizLogRetrieved;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -11,6 +12,7 @@ class QuizLog extends Model {
 
     protected $dispatchesEvents = [
         'created' => QuizLogCreated::class,
+        'retrieved' => QuizLogRetrieved::class,
     ];
 
     public function quiz() {

--- a/backend/app/Providers/EventServiceProvider.php
+++ b/backend/app/Providers/EventServiceProvider.php
@@ -5,9 +5,11 @@ namespace App\Providers;
 use App\Events\AnswerCreated;
 use App\Events\FollowLogCreated;
 use App\Events\QuizLogCreated;
+use App\Events\QuizLogRetrieved;
 use App\Listeners\HandleAnswerCreated;
 use App\Listeners\HandleFollowLogCreated;
 use App\Listeners\HandleQuizLogCreated;
+use App\Listeners\HandleQuizLogRetrieved;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -31,6 +33,9 @@ class EventServiceProvider extends ServiceProvider {
         ],
         AnswerCreated::class => [
             HandleAnswerCreated::class
+        ],
+        QuizLogRetrieved::class => [
+            HandleQuizLogRetrieved::class,
         ]
     ];
 


### PR DESCRIPTION
Asana [Task](https://app.asana.com/0/1201478050789792/1201677396904140/f)

expected output:

with `retrieved` event
we can check if the quiz log has answers or not

with this code
```php
$quiz_log = $event->quiz_log;
  if (
      $quiz_log->answers()->get()->count() === 0 &&
      now()->diffInMinutes($quiz_log->created_at) >= 1
  ) {
      $quiz_log->delete();
  }
```

we are checking for whether the current quiz log has answers
as well as checking if a minute has passed

checking if a minute has passed is necessary in order for the quiz log to not be deleted when actually taking a quiz

consequently, if the user does not complete the quiz and goes to other pages,
he has to wait a minute to take the quiz again
